### PR TITLE
Reverting Changes - closes #11

### DIFF
--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -7,17 +7,9 @@ export default Ember.Controller.extend({
     },
 
     saveReminder(reminderForm) {
-      let reminder = reminderForm.getProperties('title', 'date', 'notes', 'id');
-      reminder.date = new Date(reminder.date);
-      this.get('store').findRecord('reminder', reminder.id).then(function(targetReminder) {
-        targetReminder.setProperties({
-          title: reminder.title,
-          date: reminder.date,
-          notes: reminder.notes
-        });
-        targetReminder.save();
-      }).then(() => {
-        this.toggleProperty('isEditing');
+      let newDate = reminderForm.getProperties('date');
+      reminderForm.set('date', new Date(newDate.date));
+      reminderForm.save().then(() => { this.toggleProperty('isEditing');
       });
     },
 

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -9,12 +9,30 @@ export default Ember.Controller.extend({
     saveReminder(reminderForm) {
       let reminder = reminderForm.getProperties('title', 'date', 'notes', 'id');
       reminder.date = new Date(reminder.date);
-      this.get('store').findRecord('reminder', reminder.id).then(function(targetReminder){
-        targetReminder.setProperties({title: reminder.title, date: reminder.date, notes: reminder.notes});
+      this.get('store').findRecord('reminder', reminder.id).then(function(targetReminder) {
+        targetReminder.setProperties({
+          title: reminder.title,
+          date: reminder.date,
+          notes: reminder.notes
+        });
         targetReminder.save();
       });
       this.toggleProperty('isEditing');
+    },
+
+    revertChanges(reminderForm) {
+      console.log('yo button still working', reminderForm.get('hasDirtyAttributes'));
+      let reminder = reminderForm.getProperties('title', 'date', 'notes', 'id');
+      this.get('store').findRecord('reminder', reminder.id).then(targetReminder => {
+        if (targetReminder.get('hasDirtyAttributes')) {
+          targetReminder.rollbackAttributes();
+          this.toggleProperty('isEditing');
+        }
+      });
     }
   },
+
+  isDirtyReminder: true,
+
 
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -31,8 +31,4 @@ export default Ember.Controller.extend({
       });
     }
   },
-
-  isDirtyReminder: true,
-
-
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -16,8 +16,9 @@ export default Ember.Controller.extend({
           notes: reminder.notes
         });
         targetReminder.save();
+      }).then(() => {
+        this.toggleProperty('isEditing');
       });
-      this.toggleProperty('isEditing');
     },
 
     revertChanges(reminderForm) {

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -21,14 +21,7 @@ export default Ember.Controller.extend({
     },
 
     revertChanges(reminderForm) {
-      console.log('yo button still working', reminderForm.get('hasDirtyAttributes'));
-      let reminder = reminderForm.getProperties('title', 'date', 'notes', 'id');
-      this.get('store').findRecord('reminder', reminder.id).then(targetReminder => {
-        if (targetReminder.get('hasDirtyAttributes')) {
-          targetReminder.rollbackAttributes();
-          this.toggleProperty('isEditing');
-        }
-      });
+      reminderForm.rollbackAttributes();
     }
   },
 });

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -1,4 +1,4 @@
-<form class="new-reminder--form"{{action (action formSubmitted reminder) on="submit"}}>
+<form class="new-reminder--form" {{action (action formSubmitted reminder) on="submit"}}>
   <label>
     Title
     {{input type="text" value=reminder.title class="spec-input-title"}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,7 +3,7 @@
 
   {{#if isEditing}}
     {{reminder-form reminder=model formSubmitted=(action 'saveReminder' model) button-text="Save"}}
-    <button class="revert-changes-button"  disabled={{unless model.hasDirtyAttributes 'true'}} {{action 'revertChanges' model}}>Undo</button>
+    <button class="revert-changes-button" disabled={{unless model.hasDirtyAttributes 'true'}} {{action 'revertChanges' model}}>Undo</button>
 
   {{else}}
     <p class="spec-reminder-date">

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,6 +3,7 @@
 
   {{#if isEditing}}
     {{reminder-form reminder=model formSubmitted=(action 'saveReminder' model) button-text="Save"}}
+    <button class="revert-changes-button"  disabled={{isDirtyReminder}} {{action 'revertChanges' model}}>Undo</button>
 
   {{else}}
     <p class="spec-reminder-date">

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,7 +3,7 @@
 
   {{#if isEditing}}
     {{reminder-form reminder=model formSubmitted=(action 'saveReminder' model) button-text="Save"}}
-    <button class="revert-changes-button"  disabled={{isDirtyReminder}} {{action 'revertChanges' model}}>Undo</button>
+    <button class="revert-changes-button"  disabled={{unless model.hasDirtyAttributes 'true'}} {{action 'revertChanges' model}}>Undo</button>
 
   {{else}}
     <p class="spec-reminder-date">

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -59,7 +59,7 @@ test('clicking on new and creating a new item', function(assert) {
   });
 });
 
-test('clicking on new and creating a new item', function(assert) {
+test('clicking editing and saving a record', function(assert) {
 
   visit('/');
   click('.spec-reminder-item:first');
@@ -84,5 +84,34 @@ test('clicking on new and creating a new item', function(assert) {
 
     assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), 'brush teeth');
     assert.equal(Ember.$('.list-date:first').text().trim(), 'Wed Oct 19 2016 18:00:00 GMT-0600 (MDT)');
+  });
+});
+
+test('reverting changes to a record that is being updated', function(assert) {
+  let originalTitle;
+  visit('/');
+  click('.spec-reminder-item:first');
+
+  andThen(function() {
+    originalTitle =  find('.spec-reminder-title').text().trim();
+  });
+
+  click('.edit-reminder-button');
+
+  andThen(function() {
+    assert.equal(find('.revert-changes-button').is(':disabled'), true);
+  });
+
+  fillIn('.spec-input-title', 'brush teeth');
+
+  andThen(function() {
+    assert.equal(find('.spec-input-title').val(), "brush teeth");
+    assert.equal(find('.revert-changes-button').is(':disabled'), false);
+  });
+
+  click('.revert-changes-button');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-title').text().trim(), originalTitle);
   });
 });


### PR DESCRIPTION
## Purpose

This feature allows the user to click an undo button and revert any changes they've made to a reminder. 

## Approach

When a user edits a reminder they will now see an 'Undo' button.  The button is disabled by default.  If they edit any of the fields the button will enable.  Clicking on the button reverts all changes back to the original values. 

### Learning

Looked through the ember docs and found guides for finding a record, checking to see if it's dirty and rolling back any dirty props.  

### Test coverage 
Created an acceptance test that opens the first reminder, stores the reminder title in a variable, verifies the undo button is disabled, changes the title, verifies the button is enabled, clicks the revert-changes button and verifies the current reminder title is equal to the original title that was stored in the variable. 

@stevekinney @brittanystoroz @martensonbj 