### PR TITLE
closes #12 closes #15

### DIFF
--- a/app/controllers/reminders.js
+++ b/app/controllers/reminders.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  
+
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -19,18 +19,10 @@ export default Ember.Controller.extend({
       }).then(() => {
         this.toggleProperty('isEditing');
       });
-
     },
 
     revertChanges(reminderForm) {
-      console.log('yo button still working', reminderForm.get('hasDirtyAttributes'));
-      let reminder = reminderForm.getProperties('title', 'date', 'notes', 'id');
-      this.get('store').findRecord('reminder', reminder.id).then(targetReminder => {
-        if (targetReminder.get('hasDirtyAttributes')) {
-          targetReminder.rollbackAttributes();
-          this.toggleProperty('isEditing');
-        }
-      });
+      reminderForm.rollbackAttributes();
     },
   },
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -9,12 +9,30 @@ export default Ember.Controller.extend({
     saveReminder(reminderForm) {
       let reminder = reminderForm.getProperties('title', 'date', 'notes', 'id');
       reminder.date = new Date(reminder.date);
-      this.get('store').findRecord('reminder', reminder.id).then(function(targetReminder){
-        targetReminder.setProperties({title: reminder.title, date: reminder.date, notes: reminder.notes});
+      this.get('store').findRecord('reminder', reminder.id).then(function(targetReminder) {
+        targetReminder.setProperties({
+          title: reminder.title,
+          date: reminder.date,
+          notes: reminder.notes
+        });
         targetReminder.save();
       });
       this.toggleProperty('isEditing');
+    },
+
+    revertChanges(reminderForm) {
+      console.log('yo button still working', reminderForm.get('hasDirtyAttributes'));
+      let reminder = reminderForm.getProperties('title', 'date', 'notes', 'id');
+      this.get('store').findRecord('reminder', reminder.id).then(targetReminder => {
+        if (targetReminder.get('hasDirtyAttributes')) {
+          targetReminder.rollbackAttributes();
+          this.toggleProperty('isEditing');
+        }
+      });
     }
   },
+
+  isDirtyReminder: true,
+
 
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -16,8 +16,10 @@ export default Ember.Controller.extend({
           notes: reminder.notes
         });
         targetReminder.save();
+      }).then(() => {
+        this.toggleProperty('isEditing');
       });
-      this.toggleProperty('isEditing');
+
     },
 
     revertChanges(reminderForm) {

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -33,7 +33,9 @@ export default Ember.Controller.extend({
 
     deleteReminder(reminderForm) {
       let reminder = reminderForm.getProperties('id');
-      this.get('store').findRecord('reminder', reminder.id, {backgroundReload: false}).then(targetReminder => {
+      this.get('store').findRecord('reminder', reminder.id, {
+        backgroundReload: false
+      }).then(targetReminder => {
         targetReminder.destroyRecord();
       });
     }

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -29,10 +29,13 @@ export default Ember.Controller.extend({
           this.toggleProperty('isEditing');
         }
       });
+    },
+
+    deleteReminder(reminderForm) {
+      let reminder = reminderForm.getProperties('id');
+      this.get('store').findRecord('reminder', reminder.id, {backgroundReload: false}).then(targetReminder => {
+        targetReminder.destroyRecord();
+      });
     }
   },
-
-  isDirtyReminder: true,
-
-
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -30,14 +30,5 @@ export default Ember.Controller.extend({
         }
       });
     },
-
-    deleteReminder(reminderForm) {
-      let reminder = reminderForm.getProperties('id');
-      this.get('store').findRecord('reminder', reminder.id, {
-        backgroundReload: false
-      }).then(targetReminder => {
-        targetReminder.destroyRecord();
-      });
-    }
   },
 });

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  actions: {
+    deleteReminder(reminderForm) {
+      let reminder = reminderForm.getProperties('id');
+      this.get('store').findRecord('reminder', reminder.id, {
+        backgroundReload: false
+      }).then(targetReminder => {
+        targetReminder.destroyRecord();
+      }).then(() => {this.transitionTo('reminders');});
+    }
+  }
+});

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -2,14 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   actions: {
-    deleteReminder(reminderForm) {
-      let reminder = reminderForm.getProperties('id');
-      this.get('store').findRecord('reminder', reminder.id, {
-        backgroundReload: false
-      }).then(targetReminder => {
-        targetReminder.destroyRecord();
-      }).then(() => {this.transitionTo('reminders');});
+    deleteReminder(reminderForm){
+        reminderForm.destroyRecord().then(() => {this.transitionTo('reminders');
+      });
     },
+
     willTransition() {
       var reminder = this.controllerFor('reminders.reminder');
       reminder.set('isEditing', false);

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -9,6 +9,10 @@ export default Ember.Route.extend({
       }).then(targetReminder => {
         targetReminder.destroyRecord();
       }).then(() => {this.transitionTo('reminders');});
+    },
+    willTransition() {
+      var reminder = this.controllerFor('reminders.reminder');
+      reminder.set('isEditing', false);
     }
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -54,3 +54,7 @@ a {
   height: 50px;
   font-size:200%;
 }
+
+.unsaved-reminder {
+  background-color: red;
+}

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -1,4 +1,4 @@
-<form class="new-reminder--form"{{action (action formSubmitted reminder) on="submit"}}>
+<form class="new-reminder--form" {{action (action formSubmitted reminder) on="submit"}}>
   <label>
     Title
     {{input type="text" value=reminder.title class="spec-input-title"}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,10 +1,13 @@
 <div class='reminder-list'>
   <ul>
     {{#each model as |reminder|}}
-      <li>
+      <li class={{if reminder.hasDirtyAttributes 'unsaved-reminder' 'saved-reminder'}}>
         {{#link-to 'reminders.reminder' reminder}}
           <p class="spec-reminder-item">
             {{reminder.title}}
+            {{#if reminder.hasDirtyAttributes}}
+              💩
+            {{/if}}
           </p>
         {{/link-to}}
         <p class='list-date'>{{reminder.date}}</p>

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -19,9 +19,7 @@
 
     <button {{action 'editReminder'}} class="edit-reminder-button">Edit</button>
 
-    {{#link-to 'reminders.index'}}
-        <button {{action 'deleteReminder' model}} class="delete-reminder-button">Delete</button>
-    {{/link-to}}
+    <button {{action 'deleteReminder' model}} class="delete-reminder-button">Delete</button>
 
 
   {{/if}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,7 +3,7 @@
 
   {{#if isEditing}}
     {{reminder-form reminder=model formSubmitted=(action 'saveReminder' model) button-text="Save"}}
-    <button class="revert-changes-button"  disabled={{isDirtyReminder}} {{action 'revertChanges' model}}>Undo</button>
+    <button class="revert-changes-button"  disabled={{ unless model.hasDirtyAttributes 'true'}} {{action 'revertChanges' model}}>Undo</button>
 
   {{else}}
     <p class="spec-reminder-date">
@@ -17,6 +17,11 @@
     {{/if}}
 
     <button {{action 'editReminder'}} class="edit-reminder-button">Edit</button>
+
+    {{#link-to 'reminders.index'}}
+        <button {{action 'deleteReminder' model}} class="delete-reminder-button">Delete</button>
+    {{/link-to}}
+
 
   {{/if}}
 

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -6,6 +6,8 @@
 
     <button class="revert-changes-button"  disabled={{ unless model.hasDirtyAttributes 'true'}} {{action 'revertChanges' model}}>Undo</button>
 
+<!-- we need to bubble up an action which affects the model.  or each model is available in the each on the reminders -->
+
   {{else}}
     <p class="spec-reminder-date">
       {{model.date}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,6 +3,7 @@
 
   {{#if isEditing}}
     {{reminder-form reminder=model formSubmitted=(action 'saveReminder' model) button-text="Save"}}
+    <button class="revert-changes-button"  disabled={{isDirtyReminder}} {{action 'revertChanges' model}}>Undo</button>
 
   {{else}}
     <p class="spec-reminder-date">

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -115,3 +115,19 @@ test('reverting changes to a record that is being updated', function(assert) {
     assert.equal(Ember.$('.spec-reminder-title').text().trim(), originalTitle);
   });
 });
+
+test('deleting a reminder removes that reminder and navigates to reminders.index', function(assert) {
+  visit('/');
+  click('.spec-reminder-item:first');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-item').length, 5);
+  });
+
+  click('.delete-reminder-button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+    assert.equal(Ember.$('.spec-reminder-item').length, 4);
+  });
+});

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -107,6 +107,7 @@ test('reverting changes to a record that is being updated', function(assert) {
   andThen(function() {
     assert.equal(find('.spec-input-title').val(), "brush teeth");
     assert.equal(find('.revert-changes-button').is(':disabled'), false);
+    assert.equal(find('.unsaved-reminder').length, 1);
   });
 
   click('.revert-changes-button');

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -60,7 +60,7 @@ test('clicking on new and creating a new item', function(assert) {
 });
 
 test('clicking editing and saving a record', function(assert) {
-
+  //user visits homepage, selects first item, clicks edit, and enters new values for each input
   visit('/');
   click('.spec-reminder-item:first');
   click('.edit-reminder-button');
@@ -74,7 +74,7 @@ test('clicking editing and saving a record', function(assert) {
     assert.equal(find('.spec-input-notes').val(), "also floss, probably should do this more often");
     assert.equal(find('.new-reminder--submit').text(), "Save");
   });
-
+  //user saves those changes
   click('.new-reminder--submit');
 
   andThen(function() {
@@ -88,32 +88,30 @@ test('clicking editing and saving a record', function(assert) {
 });
 
 test('reverting changes to a record that is being updated', function(assert) {
+  //user visits page and clicks on first item, title of that item saved
   let originalTitle;
   visit('/');
   click('.spec-reminder-item:first');
-
   andThen(function() {
     originalTitle =  find('.spec-reminder-title').text().trim();
   });
-
+  //user clicks edit
   click('.edit-reminder-button');
-
   andThen(function() {
     assert.equal(find('.revert-changes-button').is(':disabled'), true);
   });
-
+  //user edits title
   fillIn('.spec-input-title', 'brush teeth');
-
   andThen(function() {
     assert.equal(find('.spec-input-title').val(), "brush teeth");
     assert.equal(find('.revert-changes-button').is(':disabled'), false);
     assert.equal(find('.unsaved-reminder').length, 1);
   });
-
+  //user clicks the revert button to undo changes
   click('.revert-changes-button');
-
   andThen(function() {
     assert.equal(Ember.$('.spec-reminder-title').text().trim(), originalTitle);
+    assert.equal(find('.unsaved-reminder').length, 0  );
   });
 });
 


### PR DESCRIPTION
## Purpose

Users can delete reminders and added a visual cue to the list on the left when an item is unsaved.

## Approach

Added a button to delete on the reminder template.  This button routes back to the index reminders.reminder route on completion.

Inside the each, we pass a class of unsaved if that reminder is dirty.

### Learning

How to route back within the controller on delete: 
https://emberigniter.com/5-essential-ember-2.0-concepts/.

WillTransition to toggle edit when we navigate away: 
http://stackoverflow.com/questions/28372064/how-to-fire-ember-js-action-on-navigating-away-from-a-page

### Test coverage 

Test when reminders are dirty that the class of 'unsaved-reminder' appears once.  Test that when no reminders are dirty that class doesn't appear at all.

Test when you delete a reminder it no longer appears on the list and you have been routed back to the index reminder.

@stevekinney @brittanystoroz @martensonbj 